### PR TITLE
enable parallelPSOCK option to allow SOCK clusters across machines

### DIFF
--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1597,7 +1597,6 @@ hydroPSO <- function(
 	 stop( "Invalid argument: 'length(upper) != nparam (", length(lower), "!=", n, ")'" )
     } else n <- length(lower)      
 
-  if (!is.na(par.hostnames) & parallel!="parallelPSOCK") {stop("par.hostnames only valid when parallel == parallelPSOCK")}
     ############################################################################
 
     con <- list(
@@ -1962,7 +1961,8 @@ hydroPSO <- function(
     ########################################################################
     ##                                parallel                             #
     ########################################################################
-    if (parallel != "none") {
+	if (!is.na(par.hostnames) & parallel!="parallelPSOCK") {stop("par.hostnames only valid when parallel == parallelPSOCK")}
+  if (parallel != "none") {
     
       if ( ( (parallel=="multicore") | (parallel=="parallel") ) & 
          ( (R.version$os=="mingw32") | (R.version$os=="mingw64") ) )

--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1992,7 +1992,7 @@ hydroPSO <- function(
         if (!is.na(par.nnodes)) {
           if (par.nnodes != par.nnodes.parallelPSOCK) {
             warning("[ 'par.nnodes != length(par.hostnames), using length(par.hostnames) instead]")
-            par.nnodes <- length(hostnames)
+            par.nnodes <- length(par.hostnames)
           } #end if unequal par.nnodes and detected
         } else {
           par.nnodes <- par.nnodes.parallelPSOCK
@@ -3188,7 +3188,7 @@ hydroPSO <- function(
     ##                                parallel                             #
     ########################################################################
     if (parallel!="none") {
-      if ( (parallel=="parallel") | (parallel=="parallelWin") )   
+      if ( (parallel=="parallel") | (parallel=="parallelWin") | (parallel=="paralellPSOCK"))   
            parallel::stopCluster(cl)   
       if (fn.name=="hydromod") {
         if (verbose) message("                                         ")

--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1322,6 +1322,7 @@ hydromod.eval <- function(part, Particles, iter, npart, maxit,
 #                                    P.S.O.                                    #
 ################################################################################
 # Author : Mauricio Zambrano-Bigiarini                                         #
+# Parallel PSOCK modifications:  Russell S. Pierce                             #
 ################################################################################
 # Started: 2008                                                                #
 # Updates: Dec-2010                                                            #
@@ -1333,7 +1334,7 @@ hydromod.eval <- function(part, Particles, iter, npart, maxit,
 #          08-Nov-2012 ; 26-Nov-2012 ; 27-Nov-2012 ; 28-Nov-2012 ; 29-Nov-2012 #
 #          19-Dec-2012                                                         #
 #          07-May-2013 ; 10-May-2013 ; 28-May-2013 ; 29-May-2013               #
-#          07-Feb-2014 ; 09-Abr-2014                                           #
+#          07-Feb-2014 ; 09-Abr-2014 ; 11-Apr-2015                             #
 ################################################################################
 # 'lower'           : minimum possible value for each parameter
 # 'upper'           : maximum possible value for each parameter

--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1596,6 +1596,7 @@ hydroPSO <- function(
 	 stop( "Invalid argument: 'length(upper) != nparam (", length(lower), "!=", n, ")'" )
     } else n <- length(lower)      
 
+  if (!is.na(par.hostnames) & parallel!="parallelPSOCK") {stop("par.hostnames only valid when parallel == parallelPSOCK")}
     ############################################################################
 
     con <- list(

--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1961,7 +1961,7 @@ hydroPSO <- function(
     ########################################################################
     ##                                parallel                             #
     ########################################################################
-	if (!is.na(par.hostnames) & parallel!="parallelPSOCK") {stop("par.hostnames only valid when parallel == parallelPSOCK")}
+	if (!all(is.na(par.hostnames)) & parallel!="parallelPSOCK") {stop("par.hostnames only valid when parallel == parallelPSOCK")}
   if (parallel != "none") {
     
       if ( ( (parallel=="multicore") | (parallel=="parallel") ) & 
@@ -1983,7 +1983,7 @@ hydroPSO <- function(
            nnodes.pc <- parallel::detectCores()
            if (verbose) message("[ Number of local cores/nodes detected: ", nnodes.pc, " ]")
            
-           if ( (parallel=="parallel") | (parallel=="parallelWin") ) {             
+           if ( (parallel=="parallel") | (parallel=="parallelWin") | (parallel="parallelPSOCK")) {             
               logfile.fname <- paste(file.path(drty.out), "/", "parallel_logfile.txt", sep="") 
               if (file.exists(logfile.fname)) file.remove(logfile.fname)
            } # IF end


### PR DESCRIPTION
The previous version of hydroPSO used makeCluster to make PSOCKclusters using the par.nnodes argument.  This is very user friendly for single machine cluster users.  However, this prevents multi-machine PSOCK cluster users as there is no user friendly way to provide the hostnames to ssh into to spawn the PSOCK instances on other machines.  

This code adds a "parallelPSOCK" parallel-type that takes par.hostnames to determine how many nodes are being launched and launches them by hostname.  

An example using localhosts only:
```
FUN2 <- function(x) {matrix(abs(x[1]+x[2])+1,1,1)}
hydroPSO(fn=FUN2, lower=c(-3,1), upper=c(5,2), control=list(write2disk=FALSE,parallel="parallelPSOCK",par.hostnames=rep("localhost",2)))
```

Items left to fix:
The spacing and commenting conventions used were a bit unclear to me, so I just did my best.  It may be better to modify them to be consistent with the rest of the code.