### PR TITLE
Update PSO_v2013.R

### DIFF
--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -2148,9 +2148,9 @@ hydroPSO <- function(
 
     if (!missing(par)) {
       if (!any(is.na(par)) && all(t(par)>=lower) && all(t(par)<=upper)) { 
-	      if (class(par)=="numeric") {
+   	      if (inherits(par, "numeric")) {
 	        X[1,] <- par 
-	      } else if ( (class(par)=="matrix") | (class(par)=="data.frame") ) {
+	      } else if ( inherits(par,"matrix") | inherits(par,"data.frame") ) {
 	          tmp <- ncol(par)
 	          if ( tmp != n )
 	            stop( "Invalid argument: 'ncol(par) != n' (",tmp, "!=", n, ")" )

--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1605,10 +1605,10 @@ hydroPSO <- function(
     # 0) Checkings and Basic computations - Start                          #
     ########################################################################
 
-    if (!missing(par)) { 
-      if (class(par)=="numeric") {
+    if (!missing(par)) {  
+      if (inherits(par, "numeric")) 
 	    n <- length(par)
-      } else if ( (class(par)=="matrix") | (class(par)=="data.frame") ) {
+      } else if ( inherits(par,"matrix") | inherits(par,"data.frame") ) {
 	      n <- ncol(par)
 	    } # ELSE IF end
     } else n <- NULL

--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1606,11 +1606,11 @@ hydroPSO <- function(
     ########################################################################
 
     if (!missing(par)) {  
-      if (inherits(par, "numeric")) 
+      if (inherits(par, "numeric")) {
 	    n <- length(par)
       } else if ( inherits(par,"matrix") | inherits(par,"data.frame") ) {
 	      n <- ncol(par)
-	    } # ELSE IF end
+	    }
     } else n <- NULL
 
     if (missing(fn)) {


### PR DESCRIPTION
the way "class" was accessed caused an error in newer R, see: https://stackoverflow.com/questions/77666748/errors-in-older-r-package-due-to-classx-returning-both-matrix-and-array-is