### PR TITLE
[codex] avoid GlobalEnv exports in hydroPSO parallel workers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,13 @@ NEWS for hydroPSO
                            -) ParamFiles.txt file now supports one additional column 'RefValue', which is used as reference for 
                               additive or multiplicative changes.
 
+                           -) Two new items within the 'control' argument in order to avoid modification of the .GlobalEnv variable  
+                              when using PSOCK clusters (parallel == "parallelWin"), which require explicitly exporting objects. The 
+                              two new items are:
+                              - par.env: environment from which the objects required by the objective function \code{fn} are exported 
+                                         to the parallel workers.
+                              - par.export: names of additional objects to be exported from \code{par.env} to the parallel workers
+
         o 'hydromod'     : 
                            -) ParamRanges.txt file now supports three new columns: 'TypeChange', 'Min4Change', 'Max4Change', 
                               representing respectively the type of change to be made to each parameter (replacement, additive, 
@@ -82,7 +89,8 @@ NEWS for hydroPSO
 
 ## Documentation:
 
-        o hydroPSO is written now in between single quotes in the Description field of the DESCRIPTION file.
+        o 'hydroPSO'               : -) Its name is written now in between single quotes in the Description field of the DESCRIPTION file.
+                                     -) Two new items within the 'control' argument are now documented: 'par.env' and 'par.export'.
 
         o 'hydroPSO2pest'          : -) Now there is a \code{value} field in the documentation, explicitly exaplaining the output of this function.
         

--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1377,7 +1377,7 @@ hydromodInR.eval <- function(part,
 #          13-Mar-2020 ; 24-Apr-2020                                           #
 #          27-Jan-2022                                                         #
 #          10-Jul-2024 ; 30-Nov-2024                                           #
-#          18-May-2026                                                         #
+#          18-May-2026 ; 22-May-2026                                           #
 ################################################################################
 # 'lower'           : minimum possible value for each parameter
 # 'upper'           : maximum possible value for each parameter

--- a/R/PSO_v2013.R
+++ b/R/PSO_v2013.R
@@ -1607,6 +1607,8 @@ hydroPSO <- function(
     # 0) Checkings and Basic computations - Start                          #
     ########################################################################
 
+    caller.env <- parent.frame()
+
     if (!missing(par)) { 
       if (is(par, "numeric")) {
 	    n <- length(par)
@@ -1694,7 +1696,9 @@ hydroPSO <- function(
 	    REPORT=100, 
 	    parallel=c("none", "multicore", "parallel", "parallelWin"),
 	    par.nnodes=NA,
-	    par.pkgs= c()
+	    par.pkgs= c(),
+	    par.env=NULL,
+	    par.export=NULL
 	       )
 
     MinMax        <- match.arg(control[["MinMax"]], con[["MinMax"]])    
@@ -1765,6 +1769,13 @@ hydroPSO <- function(
     REPORT            <- con[["REPORT"]] 
     par.nnodes        <- con[["par.nnodes"]]
     par.pkgs          <- con[["par.pkgs"]] 
+    par.env           <- con[["par.env"]]
+    if (is.null(par.env)) par.env <- caller.env
+    if (!is.environment(par.env))
+      stop("Invalid argument: 'control$par.env' must be an environment")
+    par.export        <- con[["par.export"]]
+    if (!is.null(par.export) && !is.character(par.export))
+      stop("Invalid argument: 'control$par.export' must be a character vector")
 
     ############################################################################
     ######################### Dummy checkings ##################################
@@ -2070,6 +2081,9 @@ hydroPSO <- function(
 
          #require(parallel)           
          nnodes.pc <- parallel::detectCores()
+         if (is.na(nnodes.pc)) {
+           if (is.na(par.nnodes)) nnodes.pc <- 1 else nnodes.pc <- par.nnodes
+         } # IF end
          if (verbose) message("[ Number of cores/nodes detected: ", nnodes.pc, " ]")
            
          if ( (parallel=="parallel") | (parallel=="parallelWin") ) {             
@@ -2101,16 +2115,35 @@ hydroPSO <- function(
                for(i in packages) library(i, character.only = TRUE)
              } # 'packFn' END
              parallel::clusterCall(cl, pckgFn, par.pkgs)
-             parallel::clusterExport(cl, ls.str(mode="function",envir=.GlobalEnv) )
+           } # ELSE end                   
+
+           if ( (parallel=="parallel") | (parallel=="parallelWin") ) {
+             worker.exports <- par.export
+             if (is.null(worker.exports))
+               worker.exports <- ls.str(mode="function", envir=par.env)
+
              if ( (fn.name=="hydromod") | (fn.name == "hydromodInR") ) {
-               parallel::clusterExport(cl, model.FUN.args$out.FUN)
-               #parallel::clusterExport(cl, model.FUN.args$gof.FUN)
-             } # IF end    
+               fun.args <- character()
+               for (fun.arg in c("out.FUN", "gof.FUN")) {
+                 fun.name <- model.FUN.args[[fun.arg]]
+                 if (is.character(fun.name) && length(fun.name) == 1)
+                   fun.args <- c(fun.args, fun.name)
+               } # FOR end
+               worker.exports <- c(worker.exports, fun.args)
+             } # IF end
+
              if (fn.name == "hydromodInR") {
                fn.default.vars <- as.character(formals(model.FUN))
-               parallel::clusterExport(cl, fn.default.vars[fn.default.vars %in% ls(.GlobalEnv)])
-             } # IF end            
-           } # ELSE end                   
+               worker.exports <- c(worker.exports, fn.default.vars)
+             } # IF end
+
+             worker.exports <- unique(worker.exports)
+             worker.exports <- worker.exports[nzchar(worker.exports)]
+             worker.exports <- worker.exports[worker.exports %in% ls(envir=par.env, all.names=TRUE)]
+
+             if (length(worker.exports) > 0)
+               parallel::clusterExport(cl, worker.exports, envir=par.env)
+           } # IF end
                             
            if (fn.name=="hydromod") {
              if (!("model.drty" %in% names(formals(hydromod)) )) {

--- a/man/hydroPSO.Rd
+++ b/man/hydroPSO.Rd
@@ -440,6 +440,16 @@ OPTIONAL. Used only when \code{parallel='parallelWin'} \cr
 
 list of package names (as characters) that need to be loaded on each node for allowing the objective function \code{fn} to be evaluated
 } 
+  \item{par.env}{
+OPTIONAL. Used only when \code{parallel!='none'} \cr
+
+environment from which the objects required by the objective function \code{fn} are exported to the parallel workers. By default, the environment from which \code{hydroPSO} is called is used
+} 
+  \item{par.export}{
+OPTIONAL. Used only when \code{parallel!='none'} \cr
+
+character vector with the names of additional objects to be exported from \code{par.env} to the parallel workers. By default, all functions in \code{par.env} are exported
+} 
 }
 }
 

--- a/man/hydroPSO.Rd
+++ b/man/hydroPSO.Rd
@@ -81,6 +81,7 @@ By default the hydroPSO function performs minimization of \code{fn}, but it will
 The default control arguments in hydroPSO implements the Standard PSO 2011 - SPSO2011 (see Clerc 2012; Clerc et al., 2010). At the same time, hydroPSO function provides options for clamping the maximal velocity, regrouping strategy when premature convergence is detected, time-variant acceleration coefficients, time-varying maximum velocity, (non-)linear / random / adaptive / best-ratio inertia weight definitions, random or LHS initialization of positions and velocities, synchronous or asynchronous update, 4 alternative neighbourhood topologies among others.
 
 The \code{control} argument is a list that can supply any of the following components:
+
   \describe{    
     \item{drty.in}{
 OPTIONAL. Used only when \code{fn='hydromod'} \cr

--- a/man/plot_2parOF.Rd
+++ b/man/plot_2parOF.Rd
@@ -6,8 +6,7 @@
 \description{
 Produces a scatter-based diagnostic plot to explore the relationship between two model parameters and a goodness-of-fit (GOF) metric. 
 
-This function is particularly useful in hydrological modelling to assess parameter interactions, equifinality, and behavioural regions 
-after calibration or Monte Carlo simulation.
+This function is particularly useful in hydrological modelling to assess parameter interactions, equifinality, and behavioural regions after calibration or Monte Carlo simulation.
 }
 
 \usage{


### PR DESCRIPTION
## Summary

This PR updates `hydroPSO()` so parallel worker exports no longer depend on `.GlobalEnv`.

Changes include:
- capture the caller environment and use it as the default export source for parallel workers
- add `control$par.env` for explicit worker-export environments
- add `control$par.export` for explicit extra objects to export
- export worker objects with `parallel::clusterExport(..., envir = par.env)` instead of reading from `.GlobalEnv`
- document the new control options in `man/hydroPSO.Rd`
- guard against `parallel::detectCores()` returning `NA` when `par.nnodes` is explicitly supplied

## Why

CRAN does not allow package examples or code paths to require modifying the user's `.GlobalEnv`. The previous PSOCK setup assumed helper functions and default objects were discoverable from `.GlobalEnv`, which made `parallel = "parallelWin"` fragile for CRAN-compliant examples and scripts.

## Validation

- `/Library/Frameworks/R.framework/Resources/bin/Rscript -e 'invisible(parse("R/PSO_v2013.R")); cat("parse ok\n")'`
- `/Library/Frameworks/R.framework/Resources/bin/Rscript -e 'tools::checkRd("man/hydroPSO.Rd")'`
- local smoke test for both `parallel = "parallelWin"` and `parallel = "parallel"` using helper functions defined in a local environment, confirming they do not need to be placed in `.GlobalEnv`.